### PR TITLE
Comments, compiler warnings cleanup

### DIFF
--- a/example/agent.hcl
+++ b/example/agent.hcl
@@ -8,6 +8,6 @@ plugin "triton-driver" {
 
 client {
   options = {
-    "driver.whitelist" = "triton"
+    "driver.allowlist" = "triton"
   }
 }

--- a/example/example-docker.nomad
+++ b/example/example-docker.nomad
@@ -48,7 +48,7 @@ job "redis" {
 
           labels {
             group         = "webservice-cache"
-            bob           = "label"
+            bob.bill.john = "label"
             test          = "test"
           }
 

--- a/triton/config.go
+++ b/triton/config.go
@@ -147,7 +147,7 @@ var (
 	})
 )
 
-// Config contains configuration information for the plugin
+// DriverConfig contains configuration information for the plugin
 type DriverConfig struct {
 	// decoded plugin configuration struct
 	//

--- a/triton/driver.go
+++ b/triton/driver.go
@@ -668,5 +668,5 @@ func (d *Driver) SignalTask(taskID string, signal string) error {
 func (d *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
 	d.logger.Info("Inside ExecTask")
 	// driver specific logic to execute commands in a task.
-	return nil, fmt.Errorf("Triton driver does not support exec")
+	return nil, fmt.Errorf("triton driver does not support exec")
 }

--- a/triton/handle.go
+++ b/triton/handle.go
@@ -137,7 +137,7 @@ func (h *taskHandle) run() {
 						TaskName:       h.taskConfig.Name,
 						AllocID:        h.taskConfig.AllocID,
 						Timestamp:      time.Now(),
-						Message:        fmt.Sprintf("StateChange"),
+						Message:        "StateChange",
 						DisplayMessage: fmt.Sprintf("Instance: %s, StatusChange from %s to %s.", h.instUUID, prevStatus, status),
 						Annotations:    annotations,
 					})
@@ -166,7 +166,7 @@ func (h *taskHandle) run() {
 						h.ctx.Done()
 						goto EXITCODES
 					}
-					h.handleRunError(fmt.Errorf("Triton instance status in terminal phase"), "task status: "+status)
+					h.handleRunError(fmt.Errorf("triton instance status in terminal phase"), "task status: "+status)
 					return
 				}
 			}

--- a/triton/triton.go
+++ b/triton/triton.go
@@ -39,7 +39,7 @@ const (
 	DockerRestartOnFailure = "OnFailure"
 )
 
-// tritonClientInterface encapsulates all the required AWS functionality to
+// tritonClientInterface encapsulates all the required TritonDataCenter functionality to
 // successfully run tasks via this plugin.
 type tritonClientInterface interface {
 
@@ -54,7 +54,7 @@ type tritonClientInterface interface {
 	// DockerExitCode attempts to return the ExitCode of a Docker Container
 	DockerExitCode(ctx context.Context, instUUID string) (int, error)
 
-	// UploadTemplates attempts to return the ExitCode of a Docker Container
+	// UploadTemplates is used to upload templated files to a Docker Container
 	UploadTemplates(ctx context.Context, instUUID string, dtc *drivers.TaskConfig) error
 
 	// RunTask is used to trigger the running of a new Triton instance based on the
@@ -65,13 +65,13 @@ type tritonClientInterface interface {
 	// StopTask stops the running Triton Instance
 	StopTask(ctx context.Context, instUUID string) error
 
-	// DestroyTask stops the running Triton Instance
+	// DestroyTask destroys the running Triton Instance
 	DestroyTask(ctx context.Context, instUUID string) error
 
-	// DestroyTask stops the running Triton Instance
+	// RebootTask reboots the running Triton Instance
 	RebootTask(ctx context.Context, instUUID string, dtc *drivers.TaskConfig) error
 
-	// WaitForInstState is used to wait for an instance to be a desired state
+	// WaitForInstState is used to wait for an instance to be in a desired state
 	WaitForInstState(ctx context.Context, cmpt *compute.ComputeClient, id string, state string, timeout int, interval int, execute bool) (*compute.Instance, error)
 }
 
@@ -150,7 +150,7 @@ func (c tritonClient) DockerExitCode(ctx context.Context, instUUID string) (int,
 func (c tritonClient) RunTask(ctx context.Context, dtc *drivers.TaskConfig, cfg TaskConfig) (string, *drivers.DriverNetwork, error) {
 	c.logger.Info("In_RunTask")
 
-	// instanceID Is used for query a deployed instance for both dockerapi and cloudapi
+	// instanceID is used for querying a deployed instance for both dockerapi and cloudapi
 	var instanceID string
 	// primaryIP is used for advertising the instance address via DriverNetwork
 	var primaryIP string
@@ -160,7 +160,7 @@ func (c tritonClient) RunTask(ctx context.Context, dtc *drivers.TaskConfig, cfg 
 		return "", nil, err
 	}
 
-	// Init compute client to communicate to Triton
+	// Init compute client to communicate with Triton
 	cmpt, err := c.tclient.Compute()
 	if err != nil {
 		return "", nil, err

--- a/triton/triton.go
+++ b/triton/triton.go
@@ -440,7 +440,7 @@ func (c tritonClient) buildTaskInput(ctx context.Context, dtc *drivers.TaskConfi
 
 	// Build Inputs. No Instance Provisioning or Image Pulling takes place here.
 	if cfg.Cloud.Image.Name != "" {
-		i, err := c.buiuldCloudAPIInput(ctx, dtc, cfg)
+		i, err := c.buildCloudAPIInput(ctx, dtc, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -458,7 +458,7 @@ func (c tritonClient) buildTaskInput(ctx context.Context, dtc *drivers.TaskConfi
 	return input, nil
 }
 
-func (c tritonClient) buiuldCloudAPIInput(ctx context.Context, dtc *drivers.TaskConfig, cfg TaskConfig) (*tritonInstanceInput, error) {
+func (c tritonClient) buildCloudAPIInput(ctx context.Context, dtc *drivers.TaskConfig, cfg TaskConfig) (*tritonInstanceInput, error) {
 	c.logger.Info("building input for CloudAPI")
 
 	// Handle Environment Variables and Metadata


### PR DESCRIPTION
- Cleaned up some comments
- Small cleanup to make the nitty go compiler happy, some compiler warnings were:
  - error messages should not be capitalized, not be punctuated
  - unneeded sprintf warnings